### PR TITLE
feat(open): auto-start container and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -228,7 +228,7 @@ boss open myproject claude -- --resume
 | Code | Meaning |
 | --- | --- |
 | 0 | Session ended normally |
-| 1 | Container not running, or invalid workspace name |
+| 1 | Container failed to auto-start, or invalid workspace name |
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,13 +30,15 @@ Or re-run `boss init` which handles machine initialization automatically.
 
 ## Container Not Running
 
-**Symptom:** `boss open` exits with "Container boss-sandbox is not running. Run `boss start` first."
+**Symptom:** `boss ls` or `boss rm` exits with "Container boss-sandbox is not running. Run `boss start` first."
 
 **Fix:**
 
 ```bash
 boss start
 ```
+
+> **Note:** `boss open` auto-starts the container when it is not running, so this error typically only appears with `boss ls` or `boss rm`.
 
 ## OOM / Memory Issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sublang/boss",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sublang/boss",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0",

--- a/specs/decisions/002-iteron-cli-commands.md
+++ b/specs/decisions/002-iteron-cli-commands.md
@@ -141,7 +141,7 @@ Remove a workspace directory and kill any running agent sessions in it.
 ### Trade-offs
 
 - **Some Podman knowledge needed**: For logs, restart, volume backup (documented clearly)
-- **No auto-start**: `boss open` doesn't auto-start container (clear error messages guide users)
+- **Auto-start on open**: `boss open` auto-starts the container when it is not running; `boss ls` and `boss rm` still require an explicit `boss start`
 - **Destructive rm**: `boss rm` deletes workspace; requires confirmation prompt for safety
 - **Home directory clutter**: Running agents in `~` without workspace can mix with other files
 

--- a/specs/dev/release.md
+++ b/specs/dev/release.md
@@ -39,7 +39,7 @@ Changelog entries shall be grouped under these headings (in order): `Added`, `Ch
 
 ### RELEASE-006
 
-Releases shall be triggered by pushing a git tag matching the pattern `v*` (e.g., `v1.0.0`).
+Releases shall be triggered by pushing a git tag matching the pattern `vMAJOR.MINOR.PATCH` (e.g., `v1.0.0`).
 
 ### RELEASE-007
 
@@ -53,11 +53,15 @@ The release workflow on GitHub shall:
 
 ### RELEASE-008
 
-npm packages shall be published with `--provenance` flag for supply chain security, generating a signed attestation linking the package to its source repository and build.
+npm packages shall be published with `--provenance` flag for supply chain security, generating a signed attestation linking the package to its source repository and build. Authentication shall use npm OIDC trusted publishing — static npm tokens shall not be used.
+
+### RELEASE-009
+
+Scoped packages (e.g., `@sublang/boss`) shall be published with `--access public` to ensure public availability.
 
 ## Pre-release Checklist
 
-### RELEASE-009
+### RELEASE-010
 
 Before tagging a release, the developer/agent shall verify:
 

--- a/specs/iterations/004-workspace-interaction.md
+++ b/specs/iterations/004-workspace-interaction.md
@@ -77,7 +77,7 @@ Per [DR-002 §6](../decisions/002-iteron-cli-commands.md#6-boss-rm-workspace):
 | 9 | `boss ls` with sessions `claude@~`, `bash@myproject`, `gemini@backend` running | Tree output groups by location; shows correct attached/detached status and uptime |
 | 10 | `boss rm myproject` with `claude@myproject` running | Prompts "Kill claude@myproject? [y/N]"; on `y`: session killed, `~/myproject` removed |
 | 11 | `boss rm` (no arg) | Exit non-zero; prints usage error |
-| 12 | `boss open` when container not running | Exit non-zero; prints "Container boss-sandbox is not running. Run `boss start` first." |
+| 12 | `boss open` when container not running | Auto-starts the container via `startCommand()`, then opens the session normally. |
 
 ## Dependencies
 

--- a/specs/test/workspace.md
+++ b/specs/test/workspace.md
@@ -94,6 +94,7 @@ confirmation
 
 ### WST-012
 
-Where the container is not running, `boss open`, `boss ls`,
-and `boss rm` shall exit non-zero with a "not running" message
+Where the container is not running, `boss ls` and `boss rm`
+shall exit non-zero with a "not running" message.  `boss open`
+shall auto-start the container before opening the session
 ([WSX-005](../user/workspace.md#wsx-005)).

--- a/specs/user/workspace.md
+++ b/specs/user/workspace.md
@@ -57,7 +57,8 @@ exit non-zero when workspace argument is missing
 ### WSX-005
 
 Where the sandbox container is not running, when a user runs
-`boss open`, `boss ls`, or `boss rm`, the CLI shall
-exit non-zero with a message indicating the container is not
-running and suggesting `boss start`
+`boss ls` or `boss rm`, the CLI shall exit non-zero with a
+message indicating the container is not running and suggesting
+`boss start`.  `boss open` shall auto-start the container
+instead of failing
 ([DR-002 §4](../decisions/002-iteron-cli-commands.md#4-boss-open-workspace-command----args)).

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -8,6 +8,7 @@ import {
   podmanErrorMessage,
 } from '../utils/podman.js';
 import { readConfig, validateWorkspace, KNOWN_AGENTS } from '../utils/config.js';
+import { startCommand } from './start.js';
 import { buildSessionName, validateSessionToken } from '../utils/session.js';
 import { homedir } from 'node:os';
 
@@ -96,21 +97,20 @@ export async function openCommand(
   commandObj?: { args: string[] },
 ): Promise<void> {
   try {
-    const config = await readConfig();
-    const { name } = config.container;
-
-    // Check container is running
-    if (!(await isContainerRunning(name))) {
-      console.error(`Container ${name} is not running. Run \`boss start\` first.`);
-      process.exit(1);
-    }
-
-    // Build positional args (0, 1, or 2)
+    // Validate arguments before any side effects
     const positionalArgs: string[] = [];
     if (workspace !== undefined) positionalArgs.push(workspace);
     if (command !== undefined) positionalArgs.push(command);
 
     const resolved = resolveArgs(positionalArgs);
+
+    const config = await readConfig();
+    const { name } = config.container;
+
+    // Auto-start container if not running
+    if (!(await isContainerRunning(name))) {
+      await startCommand();
+    }
 
     // Create workspace directory if needed
     if (resolved.workDir !== CONTAINER_HOME) {

--- a/tests/integration/workspace.test.ts
+++ b/tests/integration/workspace.test.ts
@@ -209,35 +209,24 @@ describe('boss rm (integration)', { timeout: 120_000, sequential: true }, () => 
 });
 
 describe('boss open when container not running (integration)', { timeout: 120_000, sequential: true }, () => {
-  // IR-004 test 12: open when container not running
-  it('errors when container is not running', async () => {
-    // Stop the container
+  // IR-004 test 12: open auto-starts container when not running
+  it('auto-starts the container when not running', async () => {
     const { stopCommand } = await import('../../src/commands/stop.js');
     await stopCommand();
 
+    const { isContainerRunning } = await import('../../src/utils/podman.js');
+    const podman = await import('../../src/utils/podman.js');
+    const { readConfig } = await import('../../src/utils/config.js');
+    const config = await readConfig();
+    expect(await isContainerRunning(config.container.name)).toBe(false);
+
+    // Mock podmanSpawn to avoid the interactive tmux session, then call
+    // the real openCommand so the auto-start wiring is exercised end-to-end.
+    const spawnSpy = vi.spyOn(podman, 'podmanSpawn').mockResolvedValue();
     const { openCommand } = await import('../../src/commands/open.js');
+    await openCommand();
+    spawnSpy.mockRestore();
 
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
-      throw new Error('process.exit');
-    }) as never);
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    try {
-      await openCommand();
-    } catch {
-      // Expected
-    }
-
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('is not running'),
-    );
-
-    exitSpy.mockRestore();
-    errorSpy.mockRestore();
-
-    // Restart for any subsequent tests
-    const { startCommand } = await import('../../src/commands/start.js');
-    await startCommand();
+    expect(await isContainerRunning(config.container.name)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- **`boss open` auto-starts the container** when it is not running, removing the need for a manual `boss start` first. Argument validation runs before the start attempt so invalid input never triggers a needless boot.
- **Tightens the release workflow tag filter** from `v*` to `v[0-9]+.[0-9]+.[0-9]+` to match the RELEASE-006 semver-only policy.
- **Adds RELEASE-008 OIDC mandate** and **RELEASE-009 `--access public`** for scoped packages to the release spec.
- Updates specs (WSX-005, WST-012, DR-002), iteration test matrix, integration test, CLI reference, and troubleshooting docs to match.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 128/128 unit tests pass
- [x] Integration test `boss open when container not running` exercises the real `openCommand` with `podmanSpawn` mocked
- [x] CI passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)